### PR TITLE
Add support for net/context

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ which is passed between steps by the runner.
 ```go
 type stepAdd struct{}
 
-func (s *stepAdd) Run(state multistep.StateBag) multistep.StepAction {
+func (s *stepAdd) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
     // Read our value and assert that it is they type we want
     value := state.Get("value").(int)
     fmt.Printf("Value is %d\n", value)
 
-	// Store some state back
-	state.Put("value", value + 1)
+    // Store some state back
+    state.Put("value", value + 1)
     return multistep.ActionContinue
 }
 
@@ -35,7 +35,7 @@ Make a runner and call your array of Steps.
 func main() {
     // Our "bag of state" that we read the value from
     state := new(multistep.BasicStateBag)
-	state.Put("value", 0)
+    state.Put("value", 0)
 
     steps := []multistep.Step{
         &stepAdd{},
@@ -46,7 +46,7 @@ func main() {
     runner := &multistep.BasicRunner{Steps: steps}
 
     // Executes the steps
-    runner.Run(state)
+    runner.Run(context.Background(), state)
 }
 ```
 

--- a/basic_runner_test.go
+++ b/basic_runner_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 func TestBasicRunner_ImplRunner(t *testing.T) {
@@ -20,7 +22,7 @@ func TestBasicRunner_Run(t *testing.T) {
 	stepB := &TestStepAcc{Data: "b"}
 
 	r := &BasicRunner{Steps: []Step{stepA, stepB}}
-	r.Run(data)
+	r.Run(context.Background(), data)
 
 	// Test run data
 	expected := []string{"a", "b"}
@@ -53,7 +55,7 @@ func TestBasicRunner_Run_Halt(t *testing.T) {
 	stepC := &TestStepAcc{Data: "c"}
 
 	r := &BasicRunner{Steps: []Step{stepA, stepB, stepC}}
-	r.Run(data)
+	r.Run(context.Background(), data)
 
 	// Test run data
 	expected := []string{"a", "b"}
@@ -86,12 +88,12 @@ func TestBasicRunner_Run_Run(t *testing.T) {
 	stepWait := &TestStepWaitForever{}
 	r := &BasicRunner{Steps: []Step{stepInt, stepWait}}
 
-	go r.Run(new(BasicStateBag))
+	go r.Run(context.Background(), new(BasicStateBag))
 	// wait until really running
 	<-ch
 
 	// now try to run aain
-	r.Run(new(BasicStateBag))
+	r.Run(context.Background(), new(BasicStateBag))
 
 	// should not get here in nominal codepath
 	t.Errorf("Was able to run an already running BasicRunner")
@@ -110,7 +112,7 @@ func TestBasicRunner_Cancel(t *testing.T) {
 	// cancelling an idle Runner is a no-op
 	r.Cancel()
 
-	go r.Run(data)
+	go r.Run(context.Background(), data)
 
 	// Wait until we reach the sync point
 	responseCh := <-ch
@@ -161,7 +163,7 @@ func TestBasicRunner_Cancel_Special(t *testing.T) {
 
 	state := new(BasicStateBag)
 	state.Put("runner", r)
-	r.Run(state)
+	r.Run(context.Background(), state)
 
 	// test that state contains cancelled
 	if _, ok := state.GetOk(StateCancelled); !ok {

--- a/debug_runner.go
+++ b/debug_runner.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+
+	"golang.org/x/net/context"
 )
 
 // DebugLocation is the location where the pause is occuring when debugging
@@ -37,7 +39,7 @@ type DebugRunner struct {
 	runner *BasicRunner
 }
 
-func (r *DebugRunner) Run(state StateBag) {
+func (r *DebugRunner) Run(ctx context.Context, state StateBag) {
 	r.l.Lock()
 	if r.runner != nil {
 		panic("already running")
@@ -64,7 +66,7 @@ func (r *DebugRunner) Run(state StateBag) {
 
 	// Then just use a basic runner to run it
 	r.runner.Steps = steps
-	r.runner.Run(state)
+	r.runner.Run(ctx, state)
 }
 
 func (r *DebugRunner) Cancel() {
@@ -100,7 +102,7 @@ type debugStepPause struct {
 	PauseFn  DebugPauseFn
 }
 
-func (s *debugStepPause) Run(state StateBag) StepAction {
+func (s *debugStepPause) Run(_ context.Context, state StateBag) StepAction {
 	s.PauseFn(DebugLocationAfterRun, s.StepName, state)
 	return ActionContinue
 }

--- a/debug_runner_test.go
+++ b/debug_runner_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 func TestDebugRunner_Impl(t *testing.T) {
@@ -39,7 +41,7 @@ func TestDebugRunner_Run(t *testing.T) {
 		PauseFn: pauseFn,
 	}
 
-	r.Run(data)
+	r.Run(context.Background(), data)
 
 	// Test data
 	expected := []string{"a", "TestStepAcc", "b", "TestStepAcc"}
@@ -66,12 +68,12 @@ func TestDebugRunner_Run_Run(t *testing.T) {
 	stepWait := &TestStepWaitForever{}
 	r := &DebugRunner{Steps: []Step{stepInt, stepWait}}
 
-	go r.Run(new(BasicStateBag))
+	go r.Run(context.Background(), new(BasicStateBag))
 	// wait until really running
 	<-ch
 
 	// now try to run aain
-	r.Run(new(BasicStateBag))
+	r.Run(context.Background(), new(BasicStateBag))
 
 	// should not get here in nominal codepath
 	t.Errorf("Was able to run an already running DebugRunner")
@@ -91,7 +93,7 @@ func TestDebugRunner_Cancel(t *testing.T) {
 	// cancelling an idle Runner is a no-op
 	r.Cancel()
 
-	go r.Run(data)
+	go r.Run(context.Background(), data)
 
 	// Wait until we reach the sync point
 	responseCh := <-ch
@@ -154,7 +156,7 @@ func TestDebugPauseDefault(t *testing.T) {
 		dr := &DebugRunner{Steps: []Step{
 			&TestStepAcc{Data: "a"},
 		}}
-		dr.Run(new(BasicStateBag))
+		dr.Run(context.Background(), new(BasicStateBag))
 		complete <- true
 	}()
 

--- a/multistep.go
+++ b/multistep.go
@@ -2,6 +2,10 @@
 // discrete steps.
 package multistep
 
+import (
+	"golang.org/x/net/context"
+)
+
 // A StepAction determines the next step to take regarding multi-step actions.
 type StepAction uint
 
@@ -26,7 +30,7 @@ type Step interface {
 	//
 	// The return value determines whether multi-step sequences continue
 	// or should halt.
-	Run(StateBag) StepAction
+	Run(context.Context, StateBag) StepAction
 
 	// Cleanup is called in reverse order of the steps that have run
 	// and allow steps to clean up after themselves. Do not assume if this
@@ -41,7 +45,7 @@ type Step interface {
 // Runner is a thing that runs one or more steps.
 type Runner interface {
 	// Run runs the steps with the given initial state.
-	Run(StateBag)
+	Run(context.Context, StateBag)
 
 	// Cancel cancels a potentially running stack of steps.
 	Cancel()

--- a/multistep_test.go
+++ b/multistep_test.go
@@ -1,5 +1,7 @@
 package multistep
 
+import "golang.org/x/net/context"
+
 // A step for testing that accumuluates data into a string slice in the
 // the state bag. It always uses the "data" key in the state bag, and will
 // initialize it.
@@ -24,7 +26,7 @@ type TestStepWaitForever struct {
 type TestStepInjectCancel struct {
 }
 
-func (s TestStepAcc) Run(state StateBag) StepAction {
+func (s TestStepAcc) Run(_ context.Context, state StateBag) StepAction {
 	s.insertData(state, "data")
 
 	if s.Halt {
@@ -48,7 +50,7 @@ func (s TestStepAcc) insertData(state StateBag, key string) {
 	state.Put(key, data)
 }
 
-func (s TestStepSync) Run(StateBag) StepAction {
+func (s TestStepSync) Run(context.Context, StateBag) StepAction {
 	ch := make(chan bool)
 	s.Ch <- ch
 	<-ch
@@ -58,14 +60,14 @@ func (s TestStepSync) Run(StateBag) StepAction {
 
 func (s TestStepSync) Cleanup(StateBag) {}
 
-func (s TestStepWaitForever) Run(StateBag) StepAction {
+func (s TestStepWaitForever) Run(context.Context, StateBag) StepAction {
 	select {}
 	return ActionContinue
 }
 
 func (s TestStepWaitForever) Cleanup(StateBag) {}
 
-func (s TestStepInjectCancel) Run(state StateBag) StepAction {
+func (s TestStepInjectCancel) Run(_ context.Context, state StateBag) StepAction {
 	r := state.Get("runner").(*BasicRunner)
 	r.state = stateCancelling
 	return ActionContinue


### PR DESCRIPTION
This changes the package's public API, and also now has a dependency on [net/context](https://godoc.org/golang.org/x/net/context), so it may not be suitable for merging, but I figured I'd throw it out there just in case.

This allows steps more immediate access to the cancellation state of the Runner, and has the added benefit of allowing a context to be strung through all the steps.

I wanted to add the concept of nested collections of steps, and giving nested runners access to the cancellation channel seemed like a prerequisite for that.

Thoughts?